### PR TITLE
updated the text, resolved issue #50

### DIFF
--- a/src/components/TestData/index.tsx
+++ b/src/components/TestData/index.tsx
@@ -58,7 +58,7 @@ const TestData: React.FC = () => {
               }
             >
               <Text color="grey-90" fontSize={12} lineHight={20}>
-                Expand all
+                {expanded.length === 1 ? 'Expand All' : 'Collapse All'}
               </Text>
             </ToggleRoot>
             {!isVRT && (


### PR DESCRIPTION
before:
![image](https://github.com/nightwatchjs/html-reporter/assets/50093149/61b94e34-2c11-4004-9cff-25a182e1472e)

When we click on the 'Expand All' button, the text remains unchanged, which may confuse the user on how to collapse all. Therefore, I've updated the text according to the state, making it more understandable for the user. It's just a small contribution, but it's still an improvement. I'm looking forward to contributing more!

after:
![image](https://github.com/nightwatchjs/html-reporter/assets/50093149/094be882-d38b-4ed3-a07c-5cd15660e81b)
