### PR TITLE
Enhanced the user interaction #50

### DIFF
--- a/src/components/TestData/index.tsx
+++ b/src/components/TestData/index.tsx
@@ -58,7 +58,7 @@ const TestData: React.FC = () => {
               }
             >
               <Text color="grey-90" fontSize={12} lineHight={20}>
-                Expand all
+                {expanded.length === 1 && expanded[0] === '' ?  "Expand all": "Collapse All" }
               </Text>
             </ToggleRoot>
             {!isVRT && (


### PR DESCRIPTION
This pull request updates the 'Expand/Collapse All' button label to reflect its current state, addressing issue #50.

Implemented changes:
- Button label switches to 'Collapse All' when the list has expanded, including when there's a single, non-empty item.
- The label reverts to 'Expand All' when the list is collapsed or contains a single empty string element.

Please review the update at your convenience.

